### PR TITLE
Idle Loops - beta - removing radar tooltip

### DIFF
--- a/idleLoops/beta/statsgraph.js
+++ b/idleLoops/beta/statsgraph.js
@@ -18,18 +18,7 @@ let statGraph = {
                     },
                 },
                 tooltips: {
-                    callbacks: {
-                        label: function (tooltipItem, data) {
-                            let label = data.datasets[tooltipItem.datasetIndex].label || '';
-
-                            if (label) {
-                                label += ': ';
-                            }
-                            label += intToString(tooltipItem.yLabel, 1);
-                            label += data.datasets[tooltipItem.datasetIndex].tooltipComplement || '';
-                            return label;
-                        }
-                    }
+                    enabled: false,
                 }
             },
             data: {


### PR DESCRIPTION
disabling the radar tooltip since you added your custom one. Also, the integrated Chart.js tooltip isn't the best with frequent redraws so it kept flashing with high stat gains