### PR TITLE
Fix drag and drop in Chrome

### DIFF
--- a/idleLoops/driver.js
+++ b/idleLoops/driver.js
@@ -314,7 +314,7 @@ function split(index) {
 function handleDragStart(event) {
     let index = event.target.getAttribute("data-index")
     draggedDecorate(index);
-    event.dataTransfer.setData('Text/html', index);
+    event.dataTransfer.setData('text/plain', index);
 }
 
 function handleDragOver(event) {
@@ -324,7 +324,7 @@ function handleDragOver(event) {
 function handleDragDrop(event) {
     let indexOfDroppedOverElement = event.target.getAttribute("data-index")
     dragExitUndecorate(indexOfDroppedOverElement);
-    let initialIndex = event.dataTransfer.getData("text/html")
+    let initialIndex = event.dataTransfer.getData("text/plain")
     moveQueuedAction(initialIndex, indexOfDroppedOverElement);
 }
 


### PR DESCRIPTION
When using text/html for the DataTransfer type, Chrome adds `<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">` in front of the text, preventing it from being properly parsed as a number. Changed type to 'text/plain' as that is exactly what we're trying to communicate anyways.