### PR TITLE
2nd Part of Rounding Fix

### DIFF
--- a/Pull_of_War/graphics.js
+++ b/Pull_of_War/graphics.js
@@ -4,7 +4,7 @@ function newUnitDiv(unit) {
 	src = "pics/"+(unit.direction!="right"?"enemy":"")+unit.type+".png"
 	different = "<img height='30' width='50' src='"+src+"'>"
 	/*if(unit.direction === "right") {
-		different = "<div id='body' class='"+unit.type+" unit' style=''> </div>" + 
+		different = "<div id='body' class='"+unit.type+" unit' style=''> </div>" +
 			"<div id='unitWeapon' class='weapon'><div class='weapon"+unit.type+"'></div> </div>";
 	}
 	else {
@@ -22,7 +22,7 @@ function updateUnitPos(y, x) {
 	console.log("updating null unit "+y+", "+x);
 	if(document.getElementById("unit"+units[y][x].id) == null)
 	console.log("sadf" +units[y][x].id);
-	document.getElementById("unit"+units[y][x].id).style.left = (units[y][x].pos +7)*11.9 + "px"; 
+	document.getElementById("unit"+units[y][x].id).style.left = (units[y][x].pos +7)*11.9 + "px";
 }
 
 function updateManaVisual() {
@@ -188,7 +188,7 @@ function changeUnitScreen(unit) {
 		"<div class='buyIncreaseAmount' id='"+type+"Increase0'>5% faster</div>"+
 		"<div class='buyVal' style='color:rgb(102, 102, 102);'>Spawn units of this type every <div id='buy02' style='color:black;'></div> seconds.</div>"+
 	"</div>"
-	
+
 	next6="<div style='width:40%;height:110px;vertical-align:top;'>"
 	button2 = addButton(type, "Attack Speed", 2)
 	button3 = addButton(type, "Move Speed", 3)
@@ -196,7 +196,7 @@ function changeUnitScreen(unit) {
 	button5 = addButton(type, "Armor", 5)
 	button6 = addButton(type, "Range", 6)
 	finish ="</div>"
-	
+
 	curUnitScreen = typeNum
 	document.getElementById("unitUpgradesBox").innerHTML = commonStart+next+next2+next25+next3+button1+next4+button4+next5+next6+button2+button3+next7+button5+button6+finish;
 	if(upgradePointsInitial[typeNum] > 0)
@@ -247,8 +247,8 @@ function updateConstructionWorkers() {
 function updateStatusUpgrades(unit, type) {
 	typeNum = convertTypeToNum(type, "right")
 	document.getElementById("buy").innerHTML=upgradePointsInitial[typeNum];
-	document.getElementById("cost").innerHTML=round(unitCosts[typeNum]);
-	document.getElementById("costSpawn").innerHTML=round(costSpawnRate[typeNum]);
+	document.getElementById("cost").innerHTML=ceil(unitCosts[typeNum]);
+	document.getElementById("costSpawn").innerHTML=ceil(costSpawnRate[typeNum]);
 	if(upgradePointsInitial[typeNum] && document.getElementById("slider").children.length == 0)
 		slider('slider');
 	if(upgradePointsInitial[typeNum])
@@ -280,7 +280,7 @@ function addButton(type, name, num) {
 function updateHover(id) {
 	unitToDisplay = getUnitById(id)
 	if(!unitToDisplay) return
-	
+
 	document.getElementById("curDamageDone").innerHTML = round2(unitToDisplay.totalDamageDone);
 	document.getElementById("curKills").innerHTML = unitToDisplay.kills;
 	document.getElementById("curHealth").innerHTML = round1(unitToDisplay.curHealth);
@@ -378,7 +378,7 @@ function redrawStoredLines(onTick){
 		ctx.strokeStyle="#000000"
 		ctx.beginPath();
 		x3 = storedArrowVisuals[i].x1+((storedArrowVisuals[i].x2-storedArrowVisuals[i].x1)/storedArrowVisuals[i].count*(storedArrowVisuals[i].count - storedArrowVisuals[i].curCount)) - 4
-		y3 = storedArrowVisuals[i].y1+((storedArrowVisuals[i].y2-storedArrowVisuals[i].y1)/storedArrowVisuals[i].count*(storedArrowVisuals[i].count - storedArrowVisuals[i].curCount)) 
+		y3 = storedArrowVisuals[i].y1+((storedArrowVisuals[i].y2-storedArrowVisuals[i].y1)/storedArrowVisuals[i].count*(storedArrowVisuals[i].count - storedArrowVisuals[i].curCount))
 		//console.log(storedArrowVisuals[i].x1+", "+storedArrowVisuals[i].y1+", "+storedArrowVisuals[i].x2+", "+storedArrowVisuals[i].y2+", " + storedArrowVisuals[i].curCount+", "+x3+", "+y3)
 		ctx.moveTo(x3,y3);
 		ctx.lineTo(x3+8,y3);
@@ -449,7 +449,7 @@ function hideAllInfo() {
 	document.getElementById("buildingsSpace").style.display = "none";
 	document.getElementById("placesSpace").style.display = "none";
 	document.getElementById("optionsPage").style.display = "none";
-	
+
 	document.getElementById("warTab").style.backgroundColor="white";
 	document.getElementById("mapTab").style.backgroundColor="white";
 	document.getElementById("territoryTab").style.backgroundColor="white";

--- a/Pull_of_War/mapvalues.js
+++ b/Pull_of_War/mapvalues.js
@@ -6,7 +6,7 @@
 		[12, 1700, 2500, 60000, 15, 0, 0, 60*38, 6, [0, 5, 4], [0, .2, .12], [0, .0005, .0004]],
 		[16, 2900, 3400, 90000, 10, 0, 0, 60*40, 4, [0, 8.5, 8], [0, .25, .25], [0, .0005, .0005]],
 		[13, 2900, 5000, 100000, 10, 0, 0, 60*40, 3, [0, 12, 11], [0, 2, 2], [0,  .001, .001]]]*/
-		
+
 var maps = [];
 var currentMapInfoNum = 0;
 
@@ -14,7 +14,7 @@ for(var level = 0; level < 50; level++) {
 	if(level % 17 === 0) createMap(maps, level, 2,'start');
 	if(level % 17 === 1) createMap(maps, level, 3, 'soldier');
 	if(level % 17 === 2) createMap(maps, level, 5, 'soldier');
-    if(level % 17 === 3) createMap(maps, level, 2, 'spear');
+	if(level % 17 === 3) createMap(maps, level, 2, 'spear');
 	if(level % 17 === 4) createMap(maps, level, 6, 'soldier');
 	if(level % 17 === 5) createMap(maps, level, 4, 'both');
 	if(level % 17 === 6) createMap(maps, level, 3, 'spear');
@@ -44,7 +44,7 @@ function createMap(maps, level, lanes, type) {
 	theMap[6] = 0;                              	  //Tower Damage TODO
 	theMap[7] =  60*(10+level*2);                              	  //Cooldown on Bonus
 	theMap[8] = lanes;                              	  //Lane Count
-	
+
 	if(type === 'start') {
 		theMap[9] = [0, 1, 0];
 		theMap[10] = [0, 0, 0];
@@ -95,9 +95,9 @@ function updateMapInfo(num) {
 	document.getElementById('mapInfo').style.display="inline-block"
 	document.getElementById('mapInfo').style.left=212+201*(num%5)+'px';
 	document.getElementById('mapInfo').style.top=20+130*(Math.floor(num/5))+'px';
-	
+
 	document.getElementById('territoryGainInfo').style.color=mapTimers[num]===0?'yellow':'black';
-	
+
 	document.getElementById('baseGoldInfo').innerHTML = intToStringRound(maps[num][0])
 	document.getElementById('territoryGainInfo').innerHTML = mapTimers[num]===0?intToStringRound(maps[num][1]):intToStringRound(maps[num][1]/5)
 	document.getElementById('fenceHealthInfo').innerHTML = intToStringRound(maps[num][2])
@@ -112,10 +112,10 @@ function updateMapTimers() {
 	if(currentMapInfoNum != -1) {
 		document.getElementById('territoryGainInfo').style.color=mapTimers[currentMapInfoNum]===0?'yellow':'black';
 		document.getElementById('territoryGainInfo').innerHTML = mapTimers[currentMapInfoNum]===0?intToStringRound(maps[currentMapInfoNum][1]):intToStringRound(maps[currentMapInfoNum][1]/5)
-		
+
 	}
 	document.getElementById("territoryGain").innerHTML = mapTimers[stage]>0?maps[stage][1]/5:maps[stage][1]
-	
+
 	for(m = 0; m < (higheststageUnlocked+1) && m < 50; m++) {
 		if(mapTimers[m]===0) {
 			document.getElementById("timer"+m).innerHTML = "<div class='timerReady'>Bonus Ready!</div>"

--- a/Pull_of_War/pullofwar.js
+++ b/Pull_of_War/pullofwar.js
@@ -44,10 +44,10 @@ timer = 0;
 //startTutorial()
 function tick() {
 	timeList.push(new Date().getTime())
-	var fps = round(50/calcAverageTime()* 20) 
+	var fps = round(50/calcAverageTime()* 20)
 	document.getElementById("fps").innerHTML = (fps > 20 ? 20 : fps)+" fps";
 	if(timeList.length > 100) timeList.splice(0, 1)
-	
+
 	totalTicks++;
 	if(stop)
 		return
@@ -72,7 +72,7 @@ function tick() {
 		timer = 0;
 	}
 	updateHover(curClickedUnit)
-	
+
 	if(totalTicks < 3 && spawnList.length == 0) { //Pause at start
 		stop = 1
 	}
@@ -105,12 +105,12 @@ function pause() {
 rateReduction = .0999999;
 function handleSpawnRates() {
 	//rateReduction = 0;
-	
+
 	//TODO: put these variables into an array
-	
+
 	//TODO: change the random spawn algorithm. Currently it'll spawn X units in potentially
 	//the same spot, and then the trigger for merging to two units triggers (this causes slowdown on mass unit # spawn)
-	//Correct formula 
+	//Correct formula
 	if(spawnAmounts[0] > 0) soldierSpawnRate -= rateReduction;
 	if(soldierSpawnRate <= 0) {
 		for(j = 0; j < spawnAmounts[0]; j++) {
@@ -214,7 +214,7 @@ function handleDamageAtEnds() {
 							document.getElementById("fenceHealth").style.display = 'none';
 						}
 					}
-					
+
 				} else {
 					units[y][x].shouldAttack = 1
 				}
@@ -225,7 +225,7 @@ function handleDamageAtEnds() {
 			}
 		}
 	}
-	
+
 	checkDoneStage()
 	updateWallHealthVisuals()
 }
@@ -279,22 +279,22 @@ function checkForUnitCollisions() {
 							if(units[y][x].id > units[z][w].id) continue //if yx is the earlier one, take the merge
 							//NOTE: this means that your units don't get pushed back while merging, but their units do
 							//because of the order the unit id's get created
-							
+
 							//average the units together
 							units[y][x].damage = average(units[y][x].damage, units[z][w].damage, units[y][x].unitCount, units[z][w].unitCount)
 							units[y][x].maxHealth = average(units[y][x].maxHealth, units[z][w].maxHealth, units[y][x].unitCount, units[z][w].unitCount) //visual purposes only
-							
+
 							totalUnitCount = units[y][x].unitCount + units[z][w].unitCount
 							totalHealthA = (units[y][x].unitCount-1)*units[y][x].actualMaxHealth + units[y][x].curHealth //represents total health the unit stack
 							totalHealthB = (units[z][w].unitCount-1)*units[z][w].actualMaxHealth + units[z][w].curHealth
 							averageHealth = average(units[y][x].actualMaxHealth, units[z][w].actualMaxHealth, units[y][x].unitCount, units[z][w].unitCount)
-							
+
 							//Fix: (trunc(healthA*100) + trunc(healthB*100))/100
 							//Fix: alternate fix, subtract by -.000001
 							//console.log(totalHealthA +","+totalHealthB+","+addbyinteger(totalHealthA, totalHealthB, 3)+","+ Math.ceil(addbyinteger(totalHealthA, totalHealthB, 3)/averageHealth))
 							newUnitCount = Math.ceil(addbyinteger(totalHealthA, totalHealthB, 3)/averageHealth)
 							temp = (totalHealthA + totalHealthB)%averageHealth
-							
+
 							if(temp < 1) { //1 because javascript rounding
 								units[y][x].curHealth = units[y][x].actualMaxHealth;
 							} else {
@@ -310,19 +310,19 @@ function checkForUnitCollisions() {
 								console.log('units[y][x].unitCount:'+units[y][x].unitCount)
 								console.log('units[z][w].unitCount:'+units[z][w].unitCount)
 								console.log('temp:'+temp)
-								
+
 							}*/
-							
+
 							units[y][x].actualMaxHealth = averageHealth;
 							units[y][x].unitCount = newUnitCount;
-							
+
 							unitsDead = totalUnitCount - newUnitCount
 							if(unitsDead * units[y][x].goldWorth) { //prevent adding NaN
 								gold += unitsDead * units[y][x].goldWorth;
 							}
 							totalDead[units[y][x].typeNum] += unitsDead
 							updateGoldVisual()
-							
+
 							tempHealth = (units[y][x].curHealth / units[y][x].maxHealth * 100)
 							document.getElementById("healthBar"+units[y][x].id).style.width = tempHealth>100?100:tempHealth + "%";
 							document.getElementById("count"+units[y][x].id).innerHTML = units[y][x].unitCount
@@ -395,7 +395,7 @@ function handleBattles() {
 					drawSpearLine(units[y][x], engageTarget);
 				}
 				count = engageTarget.unitCount
-				
+
 				engageTarget.takeDamage(units[y][x].getDamageRoll(engageTarget.typeNum))
 				units[y][x].kills += count - engageTarget.unitCount;
 				//console.log(engageTarget.id)
@@ -444,7 +444,7 @@ function removeUnit(unit, shouldAdd) {
 	var elem = document.getElementById("unit"+unit.id);
 	theParent = elem.parentNode
 	theParent.parentNode.removeChild(theParent);
-	
+
 	for(g = 0; g < units.length; g++) {
 		for(h = units[g].length - 1; h >= 0; h--) {
 			if(unit.equals(units[g][h])) {
@@ -505,7 +505,7 @@ function updateDeadUnitBonus() {
 	document.getElementById("totalDead"+curUnitScreen).innerHTML = totalDead[curUnitScreen]
 	document.getElementById("buy1").innerHTML=round2(unitValues[curUnitScreen][0]*deadUnitBonus[curUnitScreen])
 	document.getElementById("buy4").innerHTML=round2(unitValues[curUnitScreen][3]*deadUnitBonus[curUnitScreen])
-	
+
 }
 
 function tickConstruction() {
@@ -633,7 +633,7 @@ function findNearestList(unit) {
 			}
 			theIndex = nearestList.length
 			for(e = 1; e < nearestList.length; e++) {
-				if(Math.abs(units[q][w].pos - nearestList[0].pos)+Math.abs(q-nearestList[0].line)*5 < 
+				if(Math.abs(units[q][w].pos - nearestList[0].pos)+Math.abs(q-nearestList[0].line)*5 <
 				Math.abs(nearestList[e].pos - nearestList[0].pos)+Math.abs(nearestList[e].line-nearestList[0].line)*6) {
 					theIndex = e
 					break
@@ -664,13 +664,17 @@ function round(num) {
     return Math.floor(num).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 
+function ceil(num) {
+    return Math.ceil(num).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
 function roundtoFormat1(num) {
     return num.toFixed(1).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 function roundtoFormat2(num) {
     return num.toFixed(2).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
-	
+
 
 
 function convertSecToMin(sec) {


### PR DESCRIPTION
Adds the 2nd part of the fix for the rounding issue (took me a minute to realize that you had groups of functions in pullofwar.js).  Created a ceil function for Upgrade and SpawnRate costs.

Atom decided it needed to cleanup the extra whitespace throughout these files, thus the appearance of a lot of changes.  The actual changelog is as follows:

1: graphics.js; changed the cost displays from round to ceil.
2: pullofwar.js; added a ceil function for the cost displays.
3: mapvalues.js; removed the extra indentation from line 17.

