### PR TITLE
Fix Coinshop filters getting confused

### DIFF
--- a/KTL/index.html
+++ b/KTL/index.html
@@ -210,9 +210,9 @@ It continues, capturing fraction ancientCoin of your fleeting soul and sending i
             <span id="ancientCoin2" style="font-weight:bold;"></span>
         </div>
         <div style="position:absolute;right:10px;top:10px;">
-            <input type="checkbox" id="showCompleteUpgrades" onclick="toggleMaxLevelCards(this.checked);" checked><label for="showCompleteUpgrades">Show Completed Upgrades</label><br>
-            <input type="checkbox" id="showAttributeUpgrades" onclick="toggleAttributeUpgrades(this.checked);" checked><label for="showAttributeUpgrades">Show Attribute Upgrades</label><br>
-            <input type="checkbox" id="showUnaffordableUpgrades" onclick="toggleUnaffordableUpgrades(this.checked);" checked><label for="showUnaffordableUpgrades">Show Unaffordable</label>
+            <input type="checkbox" id="showCompleteUpgrades" onchange="toggleMaxLevelCards(this);" checked><label for="showCompleteUpgrades">Show Completed Upgrades</label><br>
+            <input type="checkbox" id="showAttributeUpgrades" onchange="toggleAttributeUpgrades(this);" checked><label for="showAttributeUpgrades">Show Attribute Upgrades</label><br>
+            <input type="checkbox" id="showUnaffordableUpgrades" onchange="toggleUnaffordableUpgrades(this);" checked><label for="showUnaffordableUpgrades">Show Unaffordable</label>
         </div>
         <div class="menuSeparator"></div>
         <div class="menuTitle" style="font-size:14px;text-align:center;">As you lay dying, your last thoughts are recorded by the amulet...<br><span style="font-size:16px;font-weight:bold;">IF ONLY I COULD JUST...</span></div>

--- a/KTL/ktl.js
+++ b/KTL/ktl.js
@@ -132,6 +132,7 @@ function openUseAmuletMenu(isUseable) {
 
     views.updateVal(`amuletEnabledContainer`, isUseable?"":'none', 'style.display');
 
+	refreshUpgradeVisibility();
     updateCardAffordabilityBorders();
 }
 


### PR DESCRIPTION
- Remember which coin shop filters are active and rerun all filters when a filter is changed.
- Refresh coin filtering when the coin shop is opened
- Refresh the coin filtering when a purchase is made
- Rewrite "affordable" filter so all completed upgrades are considered "affordable" since players can't see the cost of completed upgrades.
- Replace onclick with onchange for keyboard users

Note: This still won't refresh the filter when coins are earned, but it's a lot better.  Especially since it'll refresh when the shop is opened.